### PR TITLE
refactor: handle undefided capitals props turn it an optional proptype

### DIFF
--- a/src/components/CountryFlag/CountryFlag.jsx
+++ b/src/components/CountryFlag/CountryFlag.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+
 import styles from "./CountryFlag.module.css";
 
 export function CountryFlag({ country }) {
@@ -25,7 +26,7 @@ export function CountryFlag({ country }) {
         </p>
         <p className={styles.text}>
           <strong>Capital: </strong>
-          {capital}
+          {capital ? capital.join(", ") : "N/A"}
         </p>
       </section>
     </li>
@@ -43,6 +44,6 @@ CountryFlag.propTypes = {
     }).isRequired,
     population: PropTypes.number.isRequired,
     region: PropTypes.string.isRequired,
-    capital: PropTypes.arrayOf(PropTypes.string).isRequired,
+    capital: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };


### PR DESCRIPTION
Refatorado a propriedade recebida no campo "capital" pois alguns países podem ter essa propriedade como 'undefined'.
Agora se um país possuir uma capital ou mais, esse valor será renderizado e as capitais separadas por virgula.
Caso o valor da prop **capital** seja _undefined_ será renderizado a string "N/A".
A propType capital também deixa de ser obrigatória, com a remoção do 'isRequired'.